### PR TITLE
add tagging core functionality

### DIFF
--- a/lib/todolist/tags.ex
+++ b/lib/todolist/tags.ex
@@ -7,7 +7,6 @@ defmodule Todolist.Tags do
   alias Todolist.Repo
 
   alias Todolist.Tags.Tag
-  alias Todolist.Tasks.Task
 
   @doc """
   Returns the list of tags.

--- a/lib/todolist/tags.ex
+++ b/lib/todolist/tags.ex
@@ -18,7 +18,7 @@ defmodule Todolist.Tags do
 
   """
   def list_tags do
-    Repo.all(Tag)
+    Repo.all(from t in Tag, preload: [:tasks])
   end
 
   @doc """
@@ -35,7 +35,7 @@ defmodule Todolist.Tags do
       ** (Ecto.NoResultsError)
 
   """
-  def get_tag!(id), do: Repo.get!(Tag, id)
+  def get_tag!(id), do: Repo.get!(Tag, id) |> Repo.preload(:tasks)
 
   @doc """
   Creates a tag.

--- a/lib/todolist/tags.ex
+++ b/lib/todolist/tags.ex
@@ -1,0 +1,136 @@
+defmodule Todolist.Tags do
+  @moduledoc """
+  The Tags context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Todolist.Repo
+
+  alias Todolist.Tags.Tag
+  alias Todolist.Tasks.Task
+
+  @doc """
+  Returns the list of tags.
+
+  ## Examples
+
+      iex> list_tags()
+      [%Tag{}, ...]
+
+  """
+  def list_tags do
+    Repo.all(Tag)
+  end
+
+  @doc """
+  Gets a single tag.
+
+  Raises `Ecto.NoResultsError` if the Tag does not exist.
+
+  ## Examples
+
+      iex> get_tag!(123)
+      %Tag{}
+
+      iex> get_tag!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_tag!(id), do: Repo.get!(Tag, id)
+
+  @doc """
+  Creates a tag.
+
+  ## Examples
+
+      iex> create_tag(%{field: value})
+      {:ok, %Tag{}}
+
+      iex> create_tag(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_tag(attrs \\ %{}) do
+    %Tag{}
+    |> Tag.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a tag.
+
+  ## Examples
+
+      iex> update_tag(tag, %{field: new_value})
+      {:ok, %Tag{}}
+
+      iex> update_tag(tag, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_tag(%Tag{} = tag, attrs) do
+    tag
+    |> Tag.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a tag.
+
+  ## Examples
+
+      iex> delete_tag(tag)
+      {:ok, %Tag{}}
+
+      iex> delete_tag(tag)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_tag(%Tag{} = tag) do
+    Repo.delete(tag)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking tag changes.
+
+  ## Examples
+
+      iex> change_tag(tag)
+      %Ecto.Changeset{data: %Tag{}}
+
+  """
+  def change_tag(%Tag{} = tag, attrs \\ %{}) do
+    Tag.changeset(tag, attrs)
+  end
+
+  def tag_task(%Task{id: task_id}, tag_names) when is_binary(tag_names) do
+    tags =
+      tag_names
+      |> tag_name_list
+      |> Enum.map(&ensure_tag_exists/1)
+
+    Todolist.Tasks.get_task!(task_id)
+    |> Repo.preload(:tags)
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_assoc(:tags, tags)
+    |> Repo.update()
+  end
+
+  defp tag_name_list(tag_names) when is_binary(tag_names) do
+    tag_names
+    |> String.split(",")
+    |> Enum.map(fn name -> name |> String.trim() |> String.downcase() end)
+  end
+
+  defp ensure_tag_exists(tag_name) do
+    Tag.changeset(%Tag{name: tag_name}, %{})
+    |> Repo.insert()
+    |> handle_existing_tag()
+  end
+
+  defp handle_existing_tag({:ok, author}), do: author
+
+  defp handle_existing_tag({:error, changeset}) do
+    Repo.get_by!(Tag, name: changeset.changes.name)
+  end
+end

--- a/lib/todolist/tags.ex
+++ b/lib/todolist/tags.ex
@@ -105,6 +105,7 @@ defmodule Todolist.Tags do
   def tag_name_list(tag_names) when is_binary(tag_names) do
     tag_names
     |> String.split(",")
+    |> Enum.reject(&(&1 == ""))
     |> Enum.map(fn name -> name |> String.trim() |> String.downcase() end)
   end
 

--- a/lib/todolist/tags.ex
+++ b/lib/todolist/tags.ex
@@ -115,7 +115,7 @@ defmodule Todolist.Tags do
     |> handle_existing_tag()
   end
 
-  defp handle_existing_tag({:ok, author}), do: author
+  defp handle_existing_tag({:ok, tag}), do: tag
 
   defp handle_existing_tag({:error, changeset}) do
     Repo.get_by!(Tag, name: changeset.changes.name)

--- a/lib/todolist/tags.ex
+++ b/lib/todolist/tags.ex
@@ -103,26 +103,13 @@ defmodule Todolist.Tags do
     Tag.changeset(tag, attrs)
   end
 
-  def tag_task(%Task{id: task_id}, tag_names) when is_binary(tag_names) do
-    tags =
-      tag_names
-      |> tag_name_list
-      |> Enum.map(&ensure_tag_exists/1)
-
-    Todolist.Tasks.get_task!(task_id)
-    |> Repo.preload(:tags)
-    |> Ecto.Changeset.change()
-    |> Ecto.Changeset.put_assoc(:tags, tags)
-    |> Repo.update()
-  end
-
-  defp tag_name_list(tag_names) when is_binary(tag_names) do
+  def tag_name_list(tag_names) when is_binary(tag_names) do
     tag_names
     |> String.split(",")
     |> Enum.map(fn name -> name |> String.trim() |> String.downcase() end)
   end
 
-  defp ensure_tag_exists(tag_name) do
+  def ensure_tag_exists(tag_name) do
     Tag.changeset(%Tag{name: tag_name}, %{})
     |> Repo.insert()
     |> handle_existing_tag()

--- a/lib/todolist/tags/tag.ex
+++ b/lib/todolist/tags/tag.ex
@@ -1,0 +1,18 @@
+defmodule Todolist.Tags.Tag do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "tags" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(tag, attrs) do
+    tag
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> unique_constraint(:name)
+  end
+end

--- a/lib/todolist/tags/tag.ex
+++ b/lib/todolist/tags/tag.ex
@@ -4,6 +4,7 @@ defmodule Todolist.Tags.Tag do
 
   schema "tags" do
     field :name, :string
+    many_to_many :tasks, Todolist.Tasks.Task, join_through: "tasks_tags"
 
     timestamps()
   end

--- a/lib/todolist/tasks.ex
+++ b/lib/todolist/tasks.ex
@@ -13,6 +13,17 @@ defmodule Todolist.Tasks do
     |> Repo.insert()
   end
 
+  def create_task_with_tags(attrs \\ %{}) do
+    Ecto.Multi.new()
+    |> Ecto.Multi.run(:task, fn _, _ ->
+      create_task(attrs)
+    end)
+    |> Ecto.Multi.run(:tags, fn _, changes ->
+      tag_task(changes.task, attrs.tag_name)
+    end)
+    |> Repo.transaction()
+  end
+
   def get_task!(id), do: Repo.get!(Task, id) |> Repo.preload(:tags)
 
   def tag_task(%Task{id: task_id}, tag_names) when is_binary(tag_names) do

--- a/lib/todolist/tasks.ex
+++ b/lib/todolist/tasks.ex
@@ -1,7 +1,10 @@
 defmodule Todolist.Tasks do
   alias Todolist.Repo
+  alias Todolist.Tasks.Task
 
   def get_all() do
-    Repo.all(Todolist.Tasks.Task)
+    Repo.all(Task)
   end
+
+  def get_task!(id), do: Repo.get!(Task, id) |> Repo.preload(:tags)
 end

--- a/lib/todolist/tasks.ex
+++ b/lib/todolist/tasks.ex
@@ -1,10 +1,24 @@
 defmodule Todolist.Tasks do
   alias Todolist.Repo
   alias Todolist.Tasks.Task
+  alias Todolist.Tags
 
   def get_all() do
     Repo.all(Task)
   end
 
   def get_task!(id), do: Repo.get!(Task, id) |> Repo.preload(:tags)
+
+  def tag_task(%Task{id: task_id}, tag_names) when is_binary(tag_names) do
+    tags =
+      tag_names
+      |> Tags.tag_name_list()
+      |> Enum.map(&Tags.ensure_tag_exists/1)
+
+    Todolist.Tasks.get_task!(task_id)
+    |> Repo.preload(:tags)
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_assoc(:tags, tags)
+    |> Repo.update()
+  end
 end

--- a/lib/todolist/tasks.ex
+++ b/lib/todolist/tasks.ex
@@ -7,6 +7,12 @@ defmodule Todolist.Tasks do
     Repo.all(Task)
   end
 
+  def create_task(attrs \\ %{}) do
+    %Task{}
+    |> Task.changeset(attrs)
+    |> Repo.insert()
+  end
+
   def get_task!(id), do: Repo.get!(Task, id) |> Repo.preload(:tags)
 
   def tag_task(%Task{id: task_id}, tag_names) when is_binary(tag_names) do

--- a/lib/todolist/tasks/task.ex
+++ b/lib/todolist/tasks/task.ex
@@ -1,11 +1,19 @@
 defmodule Todolist.Tasks.Task do
   use Ecto.Schema
-  use Pow.Ecto.Schema
+  import Ecto.Changeset
 
   schema "tasks" do
     field(:name, :string)
     many_to_many :tags, Todolist.Tags.Tag, join_through: "tasks_tags", on_replace: :delete
 
     timestamps()
+  end
+
+  @doc false
+  def changeset(task, attrs) do
+    task
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> unique_constraint(:name)
   end
 end

--- a/lib/todolist/tasks/task.ex
+++ b/lib/todolist/tasks/task.ex
@@ -4,8 +4,8 @@ defmodule Todolist.Tasks.Task do
 
   schema "tasks" do
     field(:name, :string)
+    many_to_many :tags, Todolist.Tags.Tag, join_through: "tasks_tags", on_replace: :delete
 
     timestamps()
   end
-
 end

--- a/priv/repo/migrations/20201014062336_create_tags.exs
+++ b/priv/repo/migrations/20201014062336_create_tags.exs
@@ -1,0 +1,13 @@
+defmodule Todolist.Repo.Migrations.CreateTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:tags) do
+      add :name, :string
+
+      timestamps()
+    end
+
+    create unique_index(:tags, [:name])
+  end
+end

--- a/priv/repo/migrations/20201014063423_create_tasks_tags.exs
+++ b/priv/repo/migrations/20201014063423_create_tasks_tags.exs
@@ -1,0 +1,10 @@
+defmodule Todolist.Repo.Migrations.CreateTasksTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:tasks_tags, primary_key: false) do
+      add :task_id, references(:tasks)
+      add :tag_id, references(:tags)
+    end
+  end
+end

--- a/test/todolist/tags_test.exs
+++ b/test/todolist/tags_test.exs
@@ -3,61 +3,64 @@ defmodule Todolist.TagsTest do
 
   alias Todolist.Tags
 
+  setup do
+    %{
+      valid_attrs: %{name: "some name"},
+      update_attrs: %{name: "some updated name"},
+      invalid_attrs: %{name: nil}
+    }
+  end
+
   describe "tags" do
     alias Todolist.Tags.Tag
-
-    @valid_attrs %{name: "some name"}
-    @update_attrs %{name: "some updated name"}
-    @invalid_attrs %{name: nil}
 
     def tag_fixture(attrs \\ %{}) do
       {:ok, tag} =
         attrs
-        |> Enum.into(@valid_attrs)
         |> Tags.create_tag()
 
       %Tag{tag | tasks: []}
     end
 
-    test "list_tags/0 returns all tags" do
-      tag = tag_fixture()
+    test "list_tags/0 returns all tags", context do
+      tag = tag_fixture(context.valid_attrs)
       assert Tags.list_tags() == [tag]
     end
 
-    test "get_tag!/1 returns the tag with given id" do
-      tag = tag_fixture()
+    test "get_tag!/1 returns the tag with given id", context do
+      tag = tag_fixture(context.valid_attrs)
       assert Tags.get_tag!(tag.id) == tag
     end
 
-    test "create_tag/1 with valid data creates a tag" do
-      assert {:ok, %Tag{} = tag} = Tags.create_tag(@valid_attrs)
+    test "create_tag/1 with valid data creates a tag", context do
+      assert {:ok, %Tag{} = tag} = Tags.create_tag(context.valid_attrs)
       assert tag.name == "some name"
     end
 
-    test "create_tag/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Tags.create_tag(@invalid_attrs)
+    test "create_tag/1 with invalid data returns error changeset", context do
+      assert {:error, %Ecto.Changeset{}} = Tags.create_tag(context.invalid_attrs)
     end
 
-    test "update_tag/2 with valid data updates the tag" do
-      tag = tag_fixture()
-      assert {:ok, %Tag{} = tag} = Tags.update_tag(tag, @update_attrs)
+    test "update_tag/2 with valid data updates the tag", context do
+      tag = tag_fixture(context.valid_attrs)
+      assert {:ok, %Tag{} = tag} = Tags.update_tag(tag, context.update_attrs)
       assert tag.name == "some updated name"
     end
 
-    test "update_tag/2 with invalid data returns error changeset" do
-      tag = tag_fixture()
-      assert {:error, %Ecto.Changeset{}} = Tags.update_tag(tag, @invalid_attrs)
+    test "update_tag/2 with invalid data returns error changeset", context do
+      tag = tag_fixture(context.valid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Tags.update_tag(tag, context.invalid_attrs)
       assert tag == Tags.get_tag!(tag.id)
     end
 
-    test "delete_tag/1 deletes the tag" do
-      tag = tag_fixture()
+    test "delete_tag/1 deletes the tag", context do
+      tag = tag_fixture(context.valid_attrs)
       assert {:ok, %Tag{}} = Tags.delete_tag(tag)
       assert_raise Ecto.NoResultsError, fn -> Tags.get_tag!(tag.id) end
     end
 
-    test "change_tag/1 returns a tag changeset" do
-      tag = tag_fixture()
+    test "change_tag/1 returns a tag changeset", context do
+      tag = tag_fixture(context.valid_attrs)
       assert %Ecto.Changeset{} = Tags.change_tag(tag)
     end
 

--- a/test/todolist/tags_test.exs
+++ b/test/todolist/tags_test.exs
@@ -60,5 +60,10 @@ defmodule Todolist.TagsTest do
       tag = tag_fixture()
       assert %Ecto.Changeset{} = Tags.change_tag(tag)
     end
+
+    test "tag_name_list when given empty tag names return empty list" do
+      assert Tags.tag_name_list(",,") == []
+      assert Tags.tag_name_list("a,b,") == ["a", "b"]
+    end
   end
 end

--- a/test/todolist/tags_test.exs
+++ b/test/todolist/tags_test.exs
@@ -1,0 +1,64 @@
+defmodule Todolist.TagsTest do
+  use Todolist.DataCase
+
+  alias Todolist.Tags
+
+  describe "tags" do
+    alias Todolist.Tags.Tag
+
+    @valid_attrs %{name: "some name"}
+    @update_attrs %{name: "some updated name"}
+    @invalid_attrs %{name: nil}
+
+    def tag_fixture(attrs \\ %{}) do
+      {:ok, tag} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Tags.create_tag()
+
+      tag
+    end
+
+    test "list_tags/0 returns all tags" do
+      tag = tag_fixture()
+      assert Tags.list_tags() == [tag]
+    end
+
+    test "get_tag!/1 returns the tag with given id" do
+      tag = tag_fixture()
+      assert Tags.get_tag!(tag.id) == tag
+    end
+
+    test "create_tag/1 with valid data creates a tag" do
+      assert {:ok, %Tag{} = tag} = Tags.create_tag(@valid_attrs)
+      assert tag.name == "some name"
+    end
+
+    test "create_tag/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Tags.create_tag(@invalid_attrs)
+    end
+
+    test "update_tag/2 with valid data updates the tag" do
+      tag = tag_fixture()
+      assert {:ok, %Tag{} = tag} = Tags.update_tag(tag, @update_attrs)
+      assert tag.name == "some updated name"
+    end
+
+    test "update_tag/2 with invalid data returns error changeset" do
+      tag = tag_fixture()
+      assert {:error, %Ecto.Changeset{}} = Tags.update_tag(tag, @invalid_attrs)
+      assert tag == Tags.get_tag!(tag.id)
+    end
+
+    test "delete_tag/1 deletes the tag" do
+      tag = tag_fixture()
+      assert {:ok, %Tag{}} = Tags.delete_tag(tag)
+      assert_raise Ecto.NoResultsError, fn -> Tags.get_tag!(tag.id) end
+    end
+
+    test "change_tag/1 returns a tag changeset" do
+      tag = tag_fixture()
+      assert %Ecto.Changeset{} = Tags.change_tag(tag)
+    end
+  end
+end

--- a/test/todolist/tags_test.exs
+++ b/test/todolist/tags_test.exs
@@ -16,7 +16,7 @@ defmodule Todolist.TagsTest do
         |> Enum.into(@valid_attrs)
         |> Tags.create_tag()
 
-      tag
+      %Tag{tag | tasks: []}
     end
 
     test "list_tags/0 returns all tags" do

--- a/test/todolist/tasks_test.exs
+++ b/test/todolist/tasks_test.exs
@@ -6,13 +6,14 @@ defmodule Todolist.TasksTest do
 
   describe "tasks" do
     test "tag_task" do
-      {:ok, task} = Tasks.create_task(%{name: "foo"})
-      {:ok, task} = Tasks.tag_task(task, "foo,bar")
-      assert Enum.map(task.tags, & &1.name) == ["foo", "bar"]
+      {:ok, task} = Tasks.create_task(%{name: "todo1"})
+      {:ok, task} = Tasks.tag_task(task, "tag1,tag2")
+      assert Enum.map(task.tags, & &1.name) == ["tag1", "tag2"]
 
       first_tag = List.first(task.tags)
       tag = Tags.get_tag!(first_tag.id)
-      assert tag.name == "foo"
+      task = List.first(tag.tasks)
+      assert task.name == "todo1"
     end
   end
 end

--- a/test/todolist/tasks_test.exs
+++ b/test/todolist/tasks_test.exs
@@ -1,0 +1,13 @@
+defmodule Todolist.TasksTest do
+  use Todolist.DataCase
+
+  alias Todolist.Tasks
+
+  describe "tasks" do
+    test "tag_task" do
+      {:ok, task} = Tasks.create_task(%{name: "foo"})
+      {:ok, task} = Tasks.tag_task(task, "foo,bar")
+      assert Enum.map(task.tags, & &1.name) == ["foo", "bar"]
+    end
+  end
+end

--- a/test/todolist/tasks_test.exs
+++ b/test/todolist/tasks_test.exs
@@ -3,6 +3,7 @@ defmodule Todolist.TasksTest do
 
   alias Todolist.Tasks
   alias Todolist.Tags
+  alias Todolist.Tasks.Task
 
   describe "tasks" do
     test "tag_task" do
@@ -14,6 +15,25 @@ defmodule Todolist.TasksTest do
       tag = Tags.get_tag!(first_tag.id)
       task = List.first(tag.tasks)
       assert task.name == "todo1"
+    end
+
+    test "create_task_with_tags" do
+      {:ok, %{task: %Task{id: task_id}}} =
+        Tasks.create_task_with_tags(%{name: "todo1", tag_name: "tag1, tag2"})
+
+      task = Tasks.get_task!(task_id)
+      assert Enum.map(task.tags, & &1.name) == ["tag1", "tag2"]
+    end
+
+    test "create_task_with_tags transactionality" do
+      Ecto.Adapters.SQL.query(Todolist.Repo, "drop table tasks_tags")
+
+      assert_raise(Postgrex.Error, fn ->
+        Tasks.create_task_with_tags(%{name: "todo1", tag_name: "tag1, tag2"})
+      end)
+
+      # check that creation of task is rolled back
+      nil = Repo.get_by(Task, name: "todo1")
     end
   end
 end

--- a/test/todolist/tasks_test.exs
+++ b/test/todolist/tasks_test.exs
@@ -2,12 +2,17 @@ defmodule Todolist.TasksTest do
   use Todolist.DataCase
 
   alias Todolist.Tasks
+  alias Todolist.Tags
 
   describe "tasks" do
     test "tag_task" do
       {:ok, task} = Tasks.create_task(%{name: "foo"})
       {:ok, task} = Tasks.tag_task(task, "foo,bar")
       assert Enum.map(task.tags, & &1.name) == ["foo", "bar"]
+
+      first_tag = List.first(task.tags)
+      tag = Tags.get_tag!(first_tag.id)
+      assert tag.name == "foo"
     end
   end
 end


### PR DESCRIPTION
### Problem
User need some way to classify tasks. 

### Solution
User is able to add tags to task. Input will be in the form of "foo, bar" which internally will translate to the creation of 2 tags "foo" and "bar" which are associated with the task