### PR TITLE
add new function with test to create task and tags transactionally

### DIFF
--- a/lib/todolist/tasks.ex
+++ b/lib/todolist/tasks.ex
@@ -13,6 +13,17 @@ defmodule Todolist.Tasks do
     |> Repo.insert()
   end
 
+  def create_task_with_tags(attrs \\ %{}) do
+    Ecto.Multi.new()
+    |> Ecto.Multi.run(:task, fn _, _ ->
+      create_task(attrs)
+    end)
+    |> Ecto.Multi.run(:tags, fn _, changes ->
+      tag_task(changes.task, attrs.tag_name)
+    end)
+    |> Repo.transaction()
+  end
+
   def get_task!(id), do: Repo.get!(Task, id) |> Repo.preload(:tags)
 
   def tag_task(%Task{id: task_id}, tag_names) when is_binary(tag_names) do

--- a/test/todolist/tasks_test.exs
+++ b/test/todolist/tasks_test.exs
@@ -3,6 +3,7 @@ defmodule Todolist.TasksTest do
 
   alias Todolist.Tasks
   alias Todolist.Tags
+  alias Todolist.Tasks.Task
 
   describe "tasks" do
     test "tag_task" do
@@ -14,6 +15,25 @@ defmodule Todolist.TasksTest do
       tag = Tags.get_tag!(first_tag.id)
       task = List.first(tag.tasks)
       assert task.name == "todo1"
+    end
+
+    test "create_task_with_tags" do
+      {:ok, %{task: %Task{id: task_id}}} =
+        Tasks.create_task_with_tags(%{name: "todo1", tag_name: "tag1, tag2"})
+
+      task = Tasks.get_task!(task_id)
+      assert Enum.map(task.tags, & &1.name) == ["tag1", "tag2"]
+    end
+
+    test "create_task_with_tags transactionality" do
+      Ecto.Adapters.SQL.query(Todolist.Repo, "drop table tasks_tags")
+
+      assert_raise(Postgrex.Error, fn ->
+        Tasks.create_task_with_tags(%{name: "todo1", tag_name: "tag1, tag2"})
+      end)
+
+      # check that creation of task is rolled back
+      nil = Repo.get_by(Task, name: "todo1")
     end
   end
 end


### PR DESCRIPTION
### Problem
Currently, creation of tag and branch happens in two separate functions. If creation of tag fails, creation of task will be persisted to database. 

### Solution
Using Ecto.Multi we can make the two functions happen transactionally. If creation of tag fails, creation of task will be rolled back instead.